### PR TITLE
Allow the roll_dice to accept an `Iterator<Item=Die>` instead of a `&Vec<u32>`

### DIFF
--- a/src/commands/die_rolls.rs
+++ b/src/commands/die_rolls.rs
@@ -32,10 +32,10 @@ fn roll_dice<D: iter::Iterator<Item = Die>>(dice: D) -> u32 {
 #[min_args(2)]
 #[max_args(2)]
 pub fn roll(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
-    let num_dice = args.single::<usize>().unwrap();
+    let num_dice = args.single::<u32>().unwrap();
     let num_sides = args.single::<u32>().unwrap();
 
-    let dice = iter::repeat(Die(num_sides)).take(num_dice);
+    let dice = iter::repeat(Die(num_sides)).take(num_dice as usize);
     let result = roll_dice(dice);
 
     let response = MessageBuilder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,10 @@ fn main() {
             .prefix("~"))
         .help(&HELP)
         .unrecognised_command(|ctx, msg, unrecognised_command_name| {
-            let display_text = format!("Message is not a command `{}`", unrecognised_command_name);
+            let display_text = format!(
+                "Sorry, I didn't recognize this command: `{}`. Could you try again?",
+                unrecognised_command_name,
+            );
             if let Err(reason) = msg.channel_id.say(&ctx.http, &display_text) {
                 error!("{}", reason);
             }


### PR DESCRIPTION
And create the `Die` struct to hide the details of rolling (and hopefully some validation in the future?), and remove a two formats (that may have been unecessary? not sure), and update the error message to be a bit more friendly, and add the command to the error message for the failed command.